### PR TITLE
[data] fix: fix bug of '_io.BytesIO' object has no attribute 'startswith'

### DIFF
--- a/verl/utils/dataset/vision_utils.py
+++ b/verl/utils/dataset/vision_utils.py
@@ -26,7 +26,7 @@ def process_image(image: Union[dict, Image.Image]) -> Image.Image:
 
     if "bytes" in image:
         assert "image" not in image, "Cannot have both `bytes` and `image`"
-        image["image"] = BytesIO(image["bytes"])
+        return Image.open(BytesIO(image["bytes"]))
 
     return fetch_image(image)
 


### PR DESCRIPTION
### What does this PR do?

FIX: '_io.BytesIO' object has no attribute 'startswith'

https://github.com/volcengine/verl/issues/1976

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test
1. download the test dataset.
```
huggingface-cli download --repo-type dataset xylcbd/pgdp5k_mini
```
2. convert data to parquet format
```
import argparse
import os

import datasets

if __name__ == "__main__":
    parser = argparse.ArgumentParser()
    parser.add_argument("--local_dir", default="~/data/pgdp5k_mini")
    args = parser.parse_args()

    data_source = "xylcbd/pgdp5k_mini"
    dataset = datasets.load_dataset(data_source)
    train_dataset = dataset["train"]
    train_dataset.to_parquet(os.path.join(args.local_dir, "train.parquet"))
```
3. test dataset loading:
```
import os

import torch
from omegaconf import OmegaConf
from torch.utils.data import DataLoader
from verl.utils import hf_processor, hf_tokenizer
from verl.utils.dataset.rl_dataset import RLHFDataset, collate_fn

model_path = "Qwen/Qwen2.5-VL-3B-Instruct"
tokenizer = hf_tokenizer(model_path)
processor = hf_processor(model_path)
config = OmegaConf.create(
    {
        "prompt_key": "prompt",
        "max_prompt_length": 1024,
        "filter_overlong_prompts": True,
        "filter_overlong_prompts_workers": 2,
    }
)
dataset = RLHFDataset(
    data_files=os.path.expanduser("~/data/pgdp5k_mini/train.parquet"),
    tokenizer=tokenizer,
    config=config,
    processor=processor,
)

dataloader = DataLoader(dataset=dataset, batch_size=2, shuffle=True, drop_last=True, collate_fn=collate_fn)

a = next(iter(dataloader))

from verl import DataProto

tensors = {}
non_tensors = {}

for key, val in a.items():
    if isinstance(val, torch.Tensor):
        tensors[key] = val
    else:
        non_tensors[key] = val

data_proto = DataProto.from_dict(tensors=tensors, non_tensors=non_tensors)

assert "multi_modal_data" in data_proto.non_tensor_batch, data_proto
assert "multi_modal_inputs" in data_proto.non_tensor_batch, data_proto

data = dataset[0]["input_ids"]
output = tokenizer.batch_decode([data])[0]
print(f"type: type{output}")
print(f"\n\noutput: {output}")
```
4. Error reported before repair (no error reported after repair)
```
AttributeError: '_io.BytesIO' object has no attribute 'startswith'
```
### API and Usage Example

No change for the API.

### Design & Code Changes

No change for the design.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ).
